### PR TITLE
Add support for gw2000+ws90 (Wittboy) parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,11 @@ module.exports = function (app) {
     return (Math.round(s*0.44704*100)/100);
   }
 
+  // convert inches to mm as a float
+  function in2mm(inches) {
+    return (Math.round(inches*25.4*100)/100);
+  }
+
   plugin.start = function (options, restartPlugin) {
     var http = require('http');
     var qs = require('querystring');
@@ -96,14 +101,62 @@ module.exports = function (app) {
             }
           }
 
-          if ('windspeedmph' in q) {
-            var windSpeed = mph2mps (parseFloat (q.windspeedmph));
-            var path = 'environment.wind.speedTrue';
-            if (options.windTrue == false) 
-              path = 'environment.wind.speedApparent'; 
-            values.push ({
+
+          // GW2000/Wittboy specific stuff
+
+          if ( 'solarradiation' in q) {
+            values.push({
+              path: "environment.outside.solarRadiation",
+              value: parseFloat(q.solarradiation),
+            });
+          }
+          if ('uv' in q) {
+            values.push({
+              path: "environment.outside.uvIndex",
+              value: parseInt(q.uv),
+            });
+          }
+
+          var rain_params = [
+            "rate",
+            "event",
+            "daily",
+            "weekly",
+            "monthly",
+            "yearly",
+          ];
+
+          for (let i = 0; i < rain_params.length; i++) {
+            let key = rain_params[i][0] + "rain_piezo";
+            if (key in q) {
+              values.push({
+                path: "environment.outside.rain." + rain_params[i],
+                value: in2mm(parseFloat(q[key])),
+              });
+            }
+          }
+
+          // end of Wittboy specific stuff
+
+          if ("windspeedmph" in q) {
+            var windSpeed = mph2mps(parseFloat(q.windspeedmph));
+            var path = "environment.wind.speedTrue";
+            if (options.windTrue == false)
+              path = "environment.wind.speedApparent";
+            values.push({
               path: path,
-              value: windSpeed
+              value: windSpeed,
+            });
+          }
+
+          if ("windgustmph" in q) {
+            var windGust = mph2mps(parseFloat(q.windgustmph));
+            var path = "environment.wind.gustTrue";
+            if (options.windTrue == false)
+              path = "environment.wind.gustApparent";
+            values.push({
+              path: path,
+              value: windGust,
             });
           }
 

--- a/index.js
+++ b/index.js
@@ -204,6 +204,17 @@ module.exports = function (app) {
             });
           }
 
+          if ("maxdailygust" in q) {
+            var maxGust = mph2mps(parseFloat(q.maxdailygust));
+            var path = "environment.wind.gustMaxTrue";
+            if (options.windTrue == false)
+              path = "environment.wind.gustMaxApparent";
+            values.push({
+              path: path,
+              value: maxGust,
+            });
+          }
+
           if ('winddir' in q) {
             var windDirection = degrees2radians (parseFloat (q.winddir));
             var path = 'environment.wind.directionTrue';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-ecowitt",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "SignalK plugin for Ecowitt weather sensors",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds support for the parameters exposed by the GW2000 paired with a WS90 (together known as Wittboy).
It also calculates the heat index ('feels like') if we have both temperature and humidity for any of the sensors.

Sadly I don't have another Ecowitt device to test with, so I can't verify this doesn't break other stuff but it's only an additive change.

Would be nice for signalk to known the unit used for rainfall, but I can't seem to understand how to get it to do that

fixes #2 